### PR TITLE
Ensure providing settings is awaited

### DIFF
--- a/DropboxPaperApp.ts
+++ b/DropboxPaperApp.ts
@@ -1,7 +1,7 @@
 import { App } from '@rocket.chat/apps-ts-definition/App';
 
-import { IConfigurationExtend, IEnvironmentRead, } from '@rocket.chat/apps-ts-definition/accessors';
-import { ISetting, SettingType } from '@rocket.chat/apps-ts-definition/settings';
+import { IConfigurationExtend, IEnvironmentRead } from '@rocket.chat/apps-ts-definition/accessors';
+import { SettingType } from '@rocket.chat/apps-ts-definition/settings';
 
 import { DropboxPaperCreateCommand } from './commands/DropboxPaperCreateCommand';
 import { DropboxPaperSearchCommand } from './commands/DropboxPaperSearchCommand';
@@ -10,7 +10,7 @@ import { SettingToHttpHeader } from './handlers/SettingToHttpHeader';
 
 export class DropboxPaperApp extends App {
     protected async extendConfiguration(configuration: IConfigurationExtend, environmentRead: IEnvironmentRead): Promise<void> {
-        configuration.settings.provideSetting({
+        await configuration.settings.provideSetting({
             id: 'Dropbox_Paper_Bot',
             type: SettingType.STRING,
             packageValue: '',
@@ -20,7 +20,7 @@ export class DropboxPaperApp extends App {
             i18nDescription: 'Dropbox_Paper_Bot_Description',
         });
 
-        configuration.settings.provideSetting({
+        await configuration.settings.provideSetting({
             id: 'Dropbox_Paper_Api_Token',
             type: SettingType.STRING,
             packageValue: '',
@@ -30,7 +30,7 @@ export class DropboxPaperApp extends App {
             i18nDescription: 'Dropbox_Paper_Api_Token_Description',
         });
 
-        configuration.http.providePreRequestHandler(new SettingToHttpHeader( 'Dropbox_Paper_Api_Token', 'Authorization'));
+        configuration.http.providePreRequestHandler(new SettingToHttpHeader('Dropbox_Paper_Api_Token', 'Authorization'));
 
         await configuration.slashCommands.provideSlashCommand(new DropboxPaperCreateCommand(this));
         await configuration.slashCommands.provideSlashCommand(new DropboxPaperSearchCommand(this));

--- a/commands/DropboxPaperCreateCommand.ts
+++ b/commands/DropboxPaperCreateCommand.ts
@@ -11,24 +11,24 @@ export class DropboxPaperCreateCommand implements ISlashCommand {
     public command = 'dropbox-paper-create';
     public i18nParamsExample = 'DropboxPaperCreate_Command_Example';
     public i18nDescription = 'DropboxPaperCreate_Command_Description';
-    public providesPreview = false
+    public providesPreview = false;
 
     constructor(private readonly app: DropboxPaperApp) { }
 
     public async executor(context: SlashCommandContext, read: IRead, modify: IModify, http: IHttp): Promise<void> {
         const title = context.getArguments().slice().join(' ');
 
-        const arg = { 
-            import_format: 'plain_text'
-        }
+        const arg = {
+            import_format: 'plain_text',
+        };
 
         this.app.getLogger().log(arg);
 
-        const result = await http.post(`https://api.dropboxapi.com/2/paper/docs/create?arg=${JSON.stringify(arg)}`, { 
+        const result = await http.post(`https://api.dropboxapi.com/2/paper/docs/create?arg=${JSON.stringify(arg)}`, {
             content: title,
             headers: {
-                'Content-Type': 'application/octet-stream'
-            }
+                'Content-Type': 'application/octet-stream',
+            },
         });
 
         await sharePaper({id: result.data.doc_id, name: title}, context, read, modify);

--- a/commands/DropboxPaperSearchCommand.ts
+++ b/commands/DropboxPaperSearchCommand.ts
@@ -1,10 +1,10 @@
 import { IHttp, IModify, IPersistence, IRead } from '@rocket.chat/apps-ts-definition/accessors';
 import {
     ISlashCommand,
-    SlashCommandContext,
     ISlashCommandPreview,
     ISlashCommandPreviewItem,
-    SlashCommandPreviewItemType
+    SlashCommandContext,
+    SlashCommandPreviewItemType,
 } from '@rocket.chat/apps-ts-definition/slashcommands';
 
 import { DropboxPaperApp } from '../DropboxPaperApp';
@@ -14,38 +14,39 @@ export class DropboxPaperSearchCommand implements ISlashCommand {
     public command = 'dropbox-paper-search';
     public i18nParamsExample = 'DropboxPaperSearch_Command_Example';
     public i18nDescription = 'DropboxPaperSearch_Command_Description';
-    public providesPreview = true
+    public providesPreview = true;
 
     constructor(private readonly app: DropboxPaperApp) { }
 
     public async executor(context: SlashCommandContext, read: IRead, modify: IModify, http: IHttp): Promise<void> {
-
+        return;
     }
 
     public async previewer(context: SlashCommandContext, read: IRead, modify: IModify, http: IHttp, persis: IPersistence): Promise<ISlashCommandPreview> {
         const result = await http.post('https://api.dropboxapi.com/2/paper/docs/search', {
             data: {
                 query: context.getArguments().slice().join(' '),
-                limit: 10
+                limit: 10,
             },
             headers: {
-                'Content-Type': 'application/json'
-            }
+                'Content-Type': 'application/json',
+            },
         });
 
         return {
             i18nTitle: 'Dropbox_Paper_Preview_Title',
-            items: result.data.docs.map(doc => {
-                return { 
+            items: result.data.docs.map((doc) => {
+                return {
                     id: doc.doc_id,
                     type: SlashCommandPreviewItemType.TEXT,
-                    value: doc.title
-                }
-            })
-        }
+                    value: doc.title,
+                };
+            }),
+        };
     }
-    
+
     /** The function which gets executed whenever a user selects a preview item. */
+    // tslint:disable-next-line:max-line-length
     public async executePreviewItem(item: ISlashCommandPreviewItem, context: SlashCommandContext, read: IRead, modify: IModify, http: IHttp, persis: IPersistence): Promise<void> {
         await sharePaper({id: item.id, name: item.value}, context, read, modify);
     }
@@ -78,13 +79,13 @@ export class DropboxPaperSearchCommand implements ISlashCommand {
                 resolve({
                     i18nTitle: 'Dropbox_Paper_Preview_Title',
                     items: results.map(result => (result as any).data).map(metadata => {
-                        return { 
+                        return {
                             id: metadata.doc_id,
                             type: SlashCommandPreviewItemType.TEXT,
                             value: metadata.title
                         }
                     })
-                }) 
+                })
             })
         })
     }

--- a/lib/SharePaper.ts
+++ b/lib/SharePaper.ts
@@ -1,5 +1,5 @@
-import { SlashCommandContext } from "@rocket.chat/apps-ts-definition/slashcommands";
-import { IRead, IModify } from "@rocket.chat/apps-ts-definition/accessors";
+import { IModify, IRead } from '@rocket.chat/apps-ts-definition/accessors';
+import { SlashCommandContext } from '@rocket.chat/apps-ts-definition/slashcommands';
 
 export async function sharePaper(paper: {id: string, name: string}, context: SlashCommandContext, read: IRead, modify: IModify): Promise<void> {
     const botUsername = await read.getEnvironmentReader().getSettings().getValueById('Dropbox_Paper_Bot');


### PR DESCRIPTION
Biggest thing I saw was that you're not awaiting the providing of settings. This can lead to some strange things when installing the App, such as it installs but the settings aren't visible until after a refresh of the page.

Also, fixed some styling things. While `;`'s aren't 100% required, it is better to have them than not to (at least from my experience).